### PR TITLE
If there are more than one Gallery

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ class Gallery extends Component {
 
   componentWillUnmount(){
     const modalDiv = document.querySelector('#modal-alex-box')
-    document.querySelector('body').removeChild(modalDiv)
+    modalDiv && document.querySelector('body').removeChild(modalDiv)
   }
 
   renderThumbnails = () => {


### PR DESCRIPTION
# Changelog
- If the `#modal-alex-box` when no div is found, won't move the `removeChild`.

# Problem
- If there are some `<Gallery>`, errors occur.